### PR TITLE
Fix warning due to wrong key propType

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ class ExpandableList extends Component {
     rowNumberCloseMode: 0,
   };
 
-  _keyExtractor = (item, index) => index;
+  _keyExtractor = (item, index) => index.toString();
   scrollToEnd = (params) => this.flatList.scrollToEnd(params);
   scrollToIndex = (params) => this.flatList.scrollToIndex(params);
   scrollToItem = (params) => this.flatList.scrollToItem(params);


### PR DESCRIPTION
Exact error -> Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`.